### PR TITLE
Fix device_version call with $type float

### DIFF
--- a/src/Twig/Extension/MobileDetectExtension.php
+++ b/src/Twig/Extension/MobileDetectExtension.php
@@ -98,9 +98,9 @@ class MobileDetectExtension extends AbstractExtension
      *                             is optional and defaults to self::VERSION_TYPE_STRING. Passing an
      *                             invalid parameter will default to the this type as well.
      *
-     * @return string|float the version of the property we are trying to extract
+     * @return string|float|null the version of the property we are trying to extract
      */
-    public function deviceVersion(string $propertyName, string $type = MobileDetector::VERSION_TYPE_STRING): ?string
+    public function deviceVersion(string $propertyName, string $type = MobileDetector::VERSION_TYPE_STRING)
     {
         return $this->mobileDetector->version($propertyName, $type) ?: null;
     }

--- a/tests/Twig/Extension/MobileDetectExtensionTest.php
+++ b/tests/Twig/Extension/MobileDetectExtensionTest.php
@@ -109,18 +109,20 @@ final class MobileDetectExtensionTest extends TestCase
 
     public function testDeviceVersion(): void
     {
-        $this->mobileDetector->expects(static::exactly(2))
+        $this->mobileDetector->expects(static::exactly(3))
             ->method('version')
             ->withConsecutive(
                 [static::equalTo('Version'), static::equalTo(MobileDetector::VERSION_TYPE_STRING)],
-                [static::equalTo('Firefox'), static::equalTo(MobileDetector::VERSION_TYPE_STRING)]
+                [static::equalTo('Firefox'), static::equalTo(MobileDetector::VERSION_TYPE_STRING)],
+                [static::equalTo('Firefox'), static::equalTo(MobileDetector::VERSION_TYPE_FLOAT)]
             )
-            ->willReturn(false, '98.0')
+            ->willReturn(false, '98.0', 98.0)
         ;
         $deviceView = new DeviceView($this->requestStack);
         $extension = new MobileDetectExtension($this->requestStack, $this->mobileDetector, $deviceView, $this->config);
         static::assertNull($extension->deviceVersion('Version', MobileDetector::VERSION_TYPE_STRING));
         static::assertSame('98.0', $extension->deviceVersion('Firefox', MobileDetector::VERSION_TYPE_STRING));
+        static::assertSame(98.0, $extension->deviceVersion('Firefox', MobileDetector::VERSION_TYPE_FLOAT));
     }
 
     public function testFullViewUrlHostNull(): void


### PR DESCRIPTION
...which solves following use case:

```TWIG
<html xmlns="http://www.w3.org/1999/xhtml" lang="de" xml:lang="de">
    <head>
        ...

        {% if is_device('iOS') and deviceVersion('iOS', 'float') < 15.4  %}
            <link rel="apple-touch-icon" sizes="57x57" href="/build/images/icons/apple-touch-icon-57x57.png">
            <link rel="apple-touch-icon" sizes="60x60" href="/build/images/icons/apple-touch-icon-60x60.png">
            <link rel="apple-touch-icon" sizes="72x72" href="/build/images/icons/apple-touch-icon-72x72.png">
            <link rel="apple-touch-icon" sizes="76x76" href="/build/images/icons/apple-touch-icon-76x76.png">
        {% endif %}

        ...
```
See also https://firt.dev/notes/pwa-ios/#apple-non-standard-pwa-related-abilities

Currently the follwing error is thrown:
`MobileDetectBundle\Twig\Extension\MobileDetectExtension::deviceVersion(): Return value must be of type ?string, float returned`
![image](https://user-images.githubusercontent.com/1651297/169638433-13bd6be6-b389-4f2a-92e3-2e7cea02bfe6.png)
