### PR TITLE
docs should reflect Symfony 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 MobileDetectBundle
 ==================
 
-Symfony 3.4.x-6.0.x bundle to detect mobile devices, manage mobile view and redirect to the mobile and tablet version.
+Symfony 3.4.x-7.0 bundle to detect mobile devices, manage mobile view and redirect to the mobile and tablet version.
 
 [![Github Actions Status](https://github.com/tattali/MobileDetectBundle/actions/workflows/main.yml/badge.svg?branch=main
 )](https://github.com/tattali/MobileDetectBundle/actions/workflows/main.yml?query=branch%3Amain) [![Latest Stable Version](http://poser.pugx.org/tattali/mobile-detect-bundle/v)](https://packagist.org/packages/tattali/mobile-detect-bundle) [![Total Downloads](http://poser.pugx.org/tattali/mobile-detect-bundle/downloads)](https://packagist.org/packages/tattali/mobile-detect-bundle) [![codecov](https://codecov.io/gh/tattali/MobileDetectBundle/branch/main/graph/badge.svg?token=HWV1OYRSD9)](https://codecov.io/gh/tattali/MobileDetectBundle) [![License](http://poser.pugx.org/tattali/mobile-detect-bundle/license)](https://packagist.org/packages/tattali/mobile-detect-bundle) [![PHP Version Require](http://poser.pugx.org/tattali/mobile-detect-bundle/require/php)](https://packagist.org/packages/tattali/mobile-detect-bundle)


### PR DESCRIPTION
Arguably, that first line should match the description (Symfony 5.4-7.0).  

But arguably anyone using unmaintained versions of Symfony could go back to the original bundle this was forked from.